### PR TITLE
add rk_redundancy

### DIFF
--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -528,10 +528,13 @@ class mssqlStream(SQLStream):
                     )
                     if isinstance(rk_redundancy_days, int) and rk_redundancy_days > 0:
                         self.logger.info(
-                            f"Applying replication key redundancy of {rk_redundancy_days} days."
+                            f"Applying replication key redundancy of {rk_redundancy_days} days to the start_val {start_val}."
                         )
                         start_val -= datetime.timedelta(days=rk_redundancy_days)
-
+                        self.logger.info(
+                            f"Debug - FINAL start_val: {start_val}"
+                        )
+                    
                     else:
                         self.logger.info(
                             "No redundancy was applied"

--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -523,18 +523,28 @@ class mssqlStream(SQLStream):
                 # Apply redundancy to pull some days before the start_val
                 if start_val:
                     rk_redundancy_days = self.config.get("rk_redundancy", 0)
+                    self.logger.info(
+                        f"Debug - rk_redundancy: {rk_redundancy_days} days."
+                    )
                     if isinstance(rk_redundancy_days, int) and rk_redundancy_days > 0:
                         self.logger.info(
-                            "Applying replication key redundancy of "
-                            f"{rk_redundancy_days} days."
+                            f"Applying replication key redundancy of {rk_redundancy_days} days."
                         )
                         start_val -= datetime.timedelta(days=rk_redundancy_days)
+
+                    else:
+                        self.logger.info(
+                            "No redundancy was applied"
+                        )
 
             else:
                 start_val = self.get_starting_replication_key_value(context)
 
             if start_val:
                 query = query.where(replication_key_col >= start_val)
+                self.logger.info(
+                    f"Applying query filter: {query}"
+                )
 
         if self.ABORT_AT_RECORD_COUNT is not None:
             # Limit record count to one greater than the abort threshold.

--- a/tap_mssql/client.py
+++ b/tap_mssql/client.py
@@ -522,15 +522,15 @@ class mssqlStream(SQLStream):
 
                 # Apply redundancy to pull some days before the start_val
                 if start_val:
-                    rk_redundancy_days = self.config.get("rk_redundancy", 0)
+                    lookback_window_days = self.config.get("rk_redundancy", 0)
                     self.logger.info(
-                        f"Debug - rk_redundancy: {rk_redundancy_days} days."
+                        f"Debug - rk_redundancy: {lookback_window_days} days."
                     )
-                    if isinstance(rk_redundancy_days, int) and rk_redundancy_days > 0:
+                    if isinstance(lookback_window_days, int) and lookback_window_days > 0:
                         self.logger.info(
-                            f"Applying replication key redundancy of {rk_redundancy_days} days to the start_val {start_val}."
+                            f"Applying replication key redundancy of {lookback_window_days} days to the start_val {start_val}."
                         )
-                        start_val -= datetime.timedelta(days=rk_redundancy_days)
+                        start_val -= datetime.timedelta(days=lookback_window_days)
                         self.logger.info(
                             f"Debug - FINAL start_val: {start_val}"
                         )


### PR DESCRIPTION
If RK is a date or dateTime, check config for rk_redundancy and if exists it will subtract those days to the RK date because some datasets are built with SPs that may take time to build them and data is missed in the meantime, so this avoids missing data.